### PR TITLE
fix: align NavBar translations

### DIFF
--- a/components/NavBar.jsx
+++ b/components/NavBar.jsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { useRouter } from "next/router";
 import { Avatar } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 import { useState, useRef, useEffect } from "react";
 import { ChevronDown, Globe } from "lucide-react";
 


### PR DESCRIPTION
## Summary
- ensure NavBar translations use `next-i18next` to match SSR and client renders

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm install eslint @eslint/eslintrc eslint-config-next` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b72eda383c8324a1181f16ea00c06d