### PR TITLE
fix: position border text within circular ring

### DIFF
--- a/lib/customRenderer.js
+++ b/lib/customRenderer.js
@@ -78,7 +78,8 @@ export async function renderCustomQR(canvas, options) {
 
         // Draw border text along circle
         if (borderOptions.borderText) {
-            drawCircularText(ctx, centerX, centerY, outerRadius - strokeWidth - 4, {
+            const textRadius = outerRadius - strokeWidth / 2 - (borderOptions.borderFontSize || 14) / 2;
+            drawCircularText(ctx, centerX, centerY, textRadius, {
 
                 text: borderOptions.borderText,
                 color: borderOptions.borderTextColor || '#333333',


### PR DESCRIPTION
## Summary
- place circular border text inside stroke using a font-aware radius

## Testing
- `node --test`
- `node <renderCustomQR>` *(fails: Cannot find package 'qrcode')*


------
https://chatgpt.com/codex/tasks/task_e_68badb974c848324b393a834996c74b2