### PR TITLE
feat: add gradient rendering and corner styles

### DIFF
--- a/docs/QRDesignerModules.md
+++ b/docs/QRDesignerModules.md
@@ -136,7 +136,7 @@ Purpose: Canvas renderer used by the designer to draw QR codes with custom style
 - `drawBorderLogo(ctx, cx, cy, radius, opts)` – places a logo somewhere on the border ring.
 - `drawCenterLogo(ctx, cx, cy, imageUrl, imageOptions, qrSize)` – overlays a logo at the QR center.
 - `drawModule(ctx, x, y, size, color, type)` – draws individual QR modules.
-- `drawRoundedRect`, `drawCircleCorner`, `drawStandardCorner`, `isInCornerSquare` – helper utilities for custom shapes.
+- `drawRoundedRect`, `drawCircleCorner`, `drawSquareCorner`, `isInCornerSquare`, `createGradient` – helper utilities for custom shapes and gradients.
 
 ## lib/qr.js
 Purpose: Server‑side utilities for generating QR code images and compositing logos.

--- a/lib/customRenderer.js
+++ b/lib/customRenderer.js
@@ -50,8 +50,23 @@ export async function renderCustomQR(canvas, options) {
     // Clear canvas
     ctx.clearRect(0, 0, width, height);
 
+    // Prepare background fill (color or gradient)
+    let backgroundFill = null;
+    if (backgroundOptions.gradient) {
+        backgroundFill = createGradient(ctx, width, height, backgroundOptions.gradient);
+    } else if (backgroundOptions.color && backgroundOptions.color !== 'transparent') {
+        backgroundFill = backgroundOptions.color;
+    }
+    if (backgroundFill) {
+        ctx.fillStyle = backgroundFill;
+        ctx.fillRect(0, 0, width, height);
+    }
+
     const dotType = dotsOptions.type || 'square';
     const dotColor = dotsOptions.color || '#000000';
+    let dotFillStyle = dotsOptions.gradient
+        ? createGradient(ctx, width, height, dotsOptions.gradient)
+        : dotColor;
 
     let outerRadius = 0;
     let innerRadius = 0;
@@ -63,14 +78,6 @@ export async function renderCustomQR(canvas, options) {
         const innerBorderWidth = borderOptions.innerBorderWidth ?? moduleSize;
         outerRadius = borderOptions.outerRadius || (Math.min(width, height) / 2 - outerBorderWidth / 2);
         innerRadius = borderOptions.innerRadius || (qrSize / 2 + moduleSize * 4);
-
-        // Fill background for QR area
-        const bgColor = backgroundOptions.color || '#ffffff';
-        ctx.beginPath();
-        ctx.arc(centerX, centerY, qrSize / 2 + moduleSize, 0, 2 * Math.PI);
-        ctx.fillStyle = bgColor;
-        ctx.fill();
-
         // Fill area outside QR but inside innerRadius with random pattern
         drawCircularPattern(ctx, centerX, centerY, innerRadius, qrSize / 2, {
 
@@ -83,7 +90,7 @@ export async function renderCustomQR(canvas, options) {
         ctx.beginPath();
         ctx.arc(centerX, centerY, outerRadius, 0, 2 * Math.PI);
         ctx.arc(centerX, centerY, innerRadius, 0, 2 * Math.PI, true);
-        ctx.fillStyle = borderOptions.ringBackgroundColor || '#ffffff';
+        ctx.fillStyle = borderOptions.ringBackgroundColor || backgroundFill || '#ffffff';
         ctx.fill();
 
         // Stroke outer and inner circles to define ring
@@ -120,15 +127,6 @@ export async function renderCustomQR(canvas, options) {
         }
     }
 
-    // Draw background for non-circular mode
-    if (!backgroundOptions.color || backgroundOptions.color !== 'transparent') {
-        const bgColor = backgroundOptions.color || '#ffffff';
-        if (!needsCircularBorder) {
-            ctx.fillStyle = bgColor;
-            ctx.fillRect(0, 0, width, height);
-        }
-    }
-
     // Draw QR modules
     
     // Find corner positions for special handling
@@ -148,7 +146,7 @@ export async function renderCustomQR(canvas, options) {
             // Skip corner squares (we'll draw them separately)
             if (isInCornerSquare(x, y, cornerPositions)) continue;
 
-            drawModule(ctx, px, py, moduleSize, dotColor, dotType);
+            drawModule(ctx, px, py, moduleSize, dotFillStyle, dotType);
         }
     }
 
@@ -156,25 +154,15 @@ export async function renderCustomQR(canvas, options) {
     const cornerSquareType = cornersSquareOptions.type || 'square';
     const cornerSquareColor = cornersSquareOptions.color || '#000000';
     const cornerDotColor = cornersDotOptions.color || '#000000';
+    const cornerDotType = cornersDotOptions.type || 'dot';
 
     cornerPositions.forEach(corner => {
+        const px = startX + corner.x * moduleSize;
+        const py = startY + corner.y * moduleSize;
         if (cornerSquareType === 'circle') {
-            drawCircleCorner(ctx, 
-                startX + corner.x * moduleSize, 
-                startY + corner.y * moduleSize, 
-                moduleSize, 
-                cornerSquareColor, 
-                cornerDotColor
-            );
+            drawCircleCorner(ctx, px, py, moduleSize, cornerSquareColor, cornerDotColor, cornerDotType);
         } else {
-            drawStandardCorner(ctx, 
-                startX + corner.x * moduleSize, 
-                startY + corner.y * moduleSize, 
-                moduleSize, 
-                cornerSquareColor, 
-                cornerDotColor,
-                cornerSquareType
-            );
+            drawSquareCorner(ctx, px, py, moduleSize, cornerSquareColor, cornerDotColor, cornerSquareType, cornerDotType);
         }
     });
 
@@ -306,7 +294,7 @@ async function drawCenterLogo(ctx, centerX, centerY, imageUrl, imageOptions, qrS
 
 function drawModule(ctx, x, y, size, color, type) {
     ctx.fillStyle = color;
-    
+
     switch (type) {
         case 'dots':
             ctx.beginPath();
@@ -336,27 +324,33 @@ function drawRoundedRect(ctx, x, y, width, height, radius) {
     ctx.fill();
 }
 
-function drawCircleCorner(ctx, x, y, moduleSize, squareColor, dotColor) {
+function drawCircleCorner(ctx, x, y, moduleSize, squareColor, dotColor, dotType) {
     const size = moduleSize * 7;
     const center = size / 2;
-    
+
     // Draw outer ring
     ctx.strokeStyle = squareColor;
     ctx.lineWidth = moduleSize;
     ctx.beginPath();
     ctx.arc(x + center, y + center, center - moduleSize / 2, 0, 2 * Math.PI);
     ctx.stroke();
-    
-    // Draw inner dot
+
+    // Draw inner dot or square
     ctx.fillStyle = dotColor;
-    ctx.beginPath();
-    ctx.arc(x + center, y + center, moduleSize * 1.5, 0, 2 * Math.PI);
-    ctx.fill();
+    if (dotType === 'square') {
+        const dotSize = moduleSize * 3;
+        const dotOffset = center - dotSize / 2;
+        ctx.fillRect(x + dotOffset, y + dotOffset, dotSize, dotSize);
+    } else {
+        ctx.beginPath();
+        ctx.arc(x + center, y + center, moduleSize * 1.5, 0, 2 * Math.PI);
+        ctx.fill();
+    }
 }
 
-function drawStandardCorner(ctx, x, y, moduleSize, squareColor, dotColor, type) {
+function drawSquareCorner(ctx, x, y, moduleSize, squareColor, dotColor, type, dotType) {
     const size = moduleSize * 7;
-    
+
     // Draw outer square
     ctx.fillStyle = squareColor;
     if (type === 'extra-rounded') {
@@ -364,16 +358,26 @@ function drawStandardCorner(ctx, x, y, moduleSize, squareColor, dotColor, type) 
     } else {
         ctx.fillRect(x, y, size, size);
     }
-    
+
     // Draw inner white area
     ctx.fillStyle = '#ffffff';
-    ctx.fillRect(x + moduleSize, y + moduleSize, size - 2 * moduleSize, size - 2 * moduleSize);
-    
-    // Draw center dot
+    if (type === 'extra-rounded') {
+        drawRoundedRect(ctx, x + moduleSize, y + moduleSize, size - 2 * moduleSize, size - 2 * moduleSize, moduleSize / 2);
+    } else {
+        ctx.fillRect(x + moduleSize, y + moduleSize, size - 2 * moduleSize, size - 2 * moduleSize);
+    }
+
+    // Draw center dot or square
     ctx.fillStyle = dotColor;
     const dotSize = moduleSize * 3;
     const dotOffset = moduleSize * 2;
-    ctx.fillRect(x + dotOffset, y + dotOffset, dotSize, dotSize);
+    if (dotType === 'square') {
+        ctx.fillRect(x + dotOffset, y + dotOffset, dotSize, dotSize);
+    } else {
+        ctx.beginPath();
+        ctx.arc(x + size / 2, y + size / 2, dotSize / 2, 0, 2 * Math.PI);
+        ctx.fill();
+    }
 }
 
 function isInCornerSquare(x, y, cornerPositions) {
@@ -383,4 +387,23 @@ function isInCornerSquare(x, y, cornerPositions) {
         }
     }
     return false;
+}
+
+function createGradient(ctx, width, height, grad) {
+    const { type = 'linear', rotation = 0, colorStops = [] } = grad || {};
+    let g;
+    if (type === 'radial') {
+        const r = Math.sqrt(width * width + height * height) / 2;
+        g = ctx.createRadialGradient(width / 2, height / 2, 0, width / 2, height / 2, r);
+    } else {
+        const diag = Math.sqrt(width * width + height * height);
+        const angle = rotation;
+        const x0 = width / 2 + Math.cos(angle + Math.PI) * diag / 2;
+        const y0 = height / 2 + Math.sin(angle + Math.PI) * diag / 2;
+        const x1 = width / 2 + Math.cos(angle) * diag / 2;
+        const y1 = height / 2 + Math.sin(angle) * diag / 2;
+        g = ctx.createLinearGradient(x0, y0, x1, y1);
+    }
+    colorStops.forEach(({ offset, color }) => g.addColorStop(offset, color));
+    return g;
 }


### PR DESCRIPTION
## Summary
- support linear and radial gradients for backgrounds and dots in custom renderer
- replace circular background arc fill with full-canvas background draw
- add square/circle corner rendering options and document helpers

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node --test`
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68bb1d8f75fc8324bd862adee35865c7