### PR TITLE
Handle circle corner squares and clip custom background

### DIFF
--- a/components/QRDesigner.jsx
+++ b/components/QRDesigner.jsx
@@ -272,8 +272,7 @@ export default function QRDesigner({embedded = false, initialSnapshot = null, on
             },
             cornersSquareOptions: {
                 color: cornerSquareColor,
-                // Map custom-only types to closest library type for non-custom path
-                type: (cornerSquareType === 'circle') ? 'extra-rounded' : cornerSquareType,
+                type: cornerSquareType,
             },
             cornersDotOptions: {
                 color: cornerDotColor,
@@ -411,14 +410,24 @@ export default function QRDesigner({embedded = false, initialSnapshot = null, on
         }
         // Default to qr-code-styling
         if (!QRCodeStyling) return;
+        const libOptions = {
+            ...options,
+            cornersSquareOptions: {
+                ...options.cornersSquareOptions,
+                type:
+                    options.cornersSquareOptions?.type === 'circle'
+                        ? 'extra-rounded'
+                        : options.cornersSquareOptions?.type,
+            },
+        };
         if (!qrRef.current || qrRef.current.kind !== 'styling') {
             // Clear previous renderer DOM
             ref.current.innerHTML = '';
-            const inst = new QRCodeStyling(options);
+            const inst = new QRCodeStyling(libOptions);
             inst.append(ref.current);
             qrRef.current = {kind: 'styling', inst};
         } else {
-            qrRef.current.inst.update(options);
+            qrRef.current.inst.update(libOptions);
         }
         ensureCanvasSize();
     }, [options, displaySize, cornerSquareType, circularBorder]);

--- a/lib/customRenderer.js
+++ b/lib/customRenderer.js
@@ -46,11 +46,22 @@ export async function renderCustomQR(canvas, options) {
     const qrSize = moduleCount * moduleSize;
     const startX = (width - qrSize) / 2;
     const startY = (height - qrSize) / 2;
+    const centerX = width / 2;
+    const centerY = height / 2;
+
+    let outerBorderWidth = borderOptions.outerBorderWidth ?? moduleSize;
+    let innerBorderWidth = borderOptions.innerBorderWidth ?? moduleSize;
+    let outerRadius = 0;
+    let innerRadius = 0;
+    if (needsCircularBorder) {
+        outerRadius = borderOptions.outerRadius || (Math.min(width, height) / 2 - outerBorderWidth / 2);
+        innerRadius = borderOptions.innerRadius || (qrSize / 2 + moduleSize * 4);
+    }
 
     // Clear canvas
     ctx.clearRect(0, 0, width, height);
 
-    // Prepare background fill (color or gradient)
+    // Prepare background fill (color or gradient) limited to QR or circular border
     let backgroundFill = null;
     if (backgroundOptions.gradient) {
         backgroundFill = createGradient(ctx, width, height, backgroundOptions.gradient);
@@ -58,8 +69,17 @@ export async function renderCustomQR(canvas, options) {
         backgroundFill = backgroundOptions.color;
     }
     if (backgroundFill) {
+        ctx.save();
         ctx.fillStyle = backgroundFill;
-        ctx.fillRect(0, 0, width, height);
+        if (needsCircularBorder) {
+            ctx.beginPath();
+            ctx.arc(centerX, centerY, outerRadius, 0, 2 * Math.PI);
+            ctx.clip();
+            ctx.fillRect(centerX - outerRadius, centerY - outerRadius, outerRadius * 2, outerRadius * 2);
+        } else {
+            ctx.fillRect(startX, startY, qrSize, qrSize);
+        }
+        ctx.restore();
     }
 
     const dotType = dotsOptions.type || 'square';
@@ -68,16 +88,7 @@ export async function renderCustomQR(canvas, options) {
         ? createGradient(ctx, width, height, dotsOptions.gradient)
         : dotColor;
 
-    let outerRadius = 0;
-    let innerRadius = 0;
-    const centerX = width / 2;
-    const centerY = height / 2;
-
     if (needsCircularBorder) {
-        const outerBorderWidth = borderOptions.outerBorderWidth ?? moduleSize;
-        const innerBorderWidth = borderOptions.innerBorderWidth ?? moduleSize;
-        outerRadius = borderOptions.outerRadius || (Math.min(width, height) / 2 - outerBorderWidth / 2);
-        innerRadius = borderOptions.innerRadius || (qrSize / 2 + moduleSize * 4);
         // Fill area outside QR but inside innerRadius with random pattern
         drawCircularPattern(ctx, centerX, centerY, innerRadius, qrSize / 2, {
 
@@ -162,7 +173,17 @@ export async function renderCustomQR(canvas, options) {
         if (cornerSquareType === 'circle') {
             drawCircleCorner(ctx, px, py, moduleSize, cornerSquareColor, cornerDotColor, cornerDotType);
         } else {
-            drawSquareCorner(ctx, px, py, moduleSize, cornerSquareColor, cornerDotColor, cornerSquareType, cornerDotType);
+            drawSquareCorner(
+                ctx,
+                px,
+                py,
+                moduleSize,
+                cornerSquareColor,
+                cornerDotColor,
+                cornerSquareType,
+                cornerDotType,
+                backgroundFill
+            );
         }
     });
 
@@ -348,7 +369,7 @@ function drawCircleCorner(ctx, x, y, moduleSize, squareColor, dotColor, dotType)
     }
 }
 
-function drawSquareCorner(ctx, x, y, moduleSize, squareColor, dotColor, type, dotType) {
+function drawSquareCorner(ctx, x, y, moduleSize, squareColor, dotColor, type, dotType, backgroundFill) {
     const size = moduleSize * 7;
 
     // Draw outer square
@@ -359,12 +380,48 @@ function drawSquareCorner(ctx, x, y, moduleSize, squareColor, dotColor, type, do
         ctx.fillRect(x, y, size, size);
     }
 
-    // Draw inner white area
-    ctx.fillStyle = '#ffffff';
+    // Carve out inner area with background fill or transparency
     if (type === 'extra-rounded') {
-        drawRoundedRect(ctx, x + moduleSize, y + moduleSize, size - 2 * moduleSize, size - 2 * moduleSize, moduleSize / 2);
+        if (backgroundFill) {
+            ctx.fillStyle = backgroundFill;
+            drawRoundedRect(
+                ctx,
+                x + moduleSize,
+                y + moduleSize,
+                size - 2 * moduleSize,
+                size - 2 * moduleSize,
+                moduleSize / 2
+            );
+        } else {
+            ctx.save();
+            ctx.globalCompositeOperation = 'destination-out';
+            drawRoundedRect(
+                ctx,
+                x + moduleSize,
+                y + moduleSize,
+                size - 2 * moduleSize,
+                size - 2 * moduleSize,
+                moduleSize / 2
+            );
+            ctx.restore();
+        }
     } else {
-        ctx.fillRect(x + moduleSize, y + moduleSize, size - 2 * moduleSize, size - 2 * moduleSize);
+        if (backgroundFill) {
+            ctx.fillStyle = backgroundFill;
+            ctx.fillRect(
+                x + moduleSize,
+                y + moduleSize,
+                size - 2 * moduleSize,
+                size - 2 * moduleSize
+            );
+        } else {
+            ctx.clearRect(
+                x + moduleSize,
+                y + moduleSize,
+                size - 2 * moduleSize,
+                size - 2 * moduleSize
+            );
+        }
     }
 
     // Draw center dot or square


### PR DESCRIPTION
## Summary
- Preserve `circle` corner style when building options and only map to `extra-rounded` when using `qr-code-styling`
- Restrict background fills in the custom renderer to the QR area or circular border to avoid overdraw
- Fill custom corner squares with the main background or transparency instead of hard-coded white

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68bb225077c48324bdf1d441d523d548