### PR TITLE
feat: integrate Coloris color picker

### DIFF
--- a/components/QRDesigner.jsx
+++ b/components/QRDesigner.jsx
@@ -974,9 +974,9 @@ export default function QRDesigner({embedded = false, initialSnapshot = null, on
                                                 <Label className="block mb-2 flex items-center gap-2">
                                                     <Palette className="size-4"/> {t("designerEditor.styleTab.dotsColor")}
                                                 </Label>
-                                                <Input type="color" value={dotColor}
+                                                <Input type="text" data-coloris value={dotColor}
                                                        onChange={(e) => setDotColor(e.target.value)}
-                                                       className="h-10 w-full cursor-pointer"/>
+                                                       className="h-10 w-full"/>
                                             </div>
                                         ) : (
                                             <div className="space-y-3">
@@ -984,15 +984,15 @@ export default function QRDesigner({embedded = false, initialSnapshot = null, on
                                                     <Palette className="size-4"/> {t("designerEditor.styleTab.dotsGradient")}
                                                 </Label>
                                                 <div className="grid grid-cols-2 gap-2">
-                                                    <Input type="color" value={dotGradStart}
+                                                    <Input type="text" data-coloris value={dotGradStart}
                                                            onChange={(e) => setDotGradStart(e.target.value)}
                                                            placeholder={t("designerEditor.styleTab.start")}/>
                                                     {dotGradStops === 3 && (
-                                                        <Input type="color" value={dotGradMid}
+                                                        <Input type="text" data-coloris value={dotGradMid}
                                                                onChange={(e) => setDotGradMid(e.target.value)}
                                                                placeholder={t("designerEditor.styleTab.middle")}/>
                                                     )}
-                                                    <Input type="color" value={dotGradEnd}
+                                                    <Input type="text" data-coloris value={dotGradEnd}
                                                            onChange={(e) => setDotGradEnd(e.target.value)}
                                                            placeholder={t("designerEditor.styleTab.end")}/>
                                                 </div>
@@ -1036,9 +1036,9 @@ export default function QRDesigner({embedded = false, initialSnapshot = null, on
                                                 <Label className="block mb-2 flex items-center gap-2">
                                                     <Palette className="size-4"/> {t("designerEditor.styleTab.backgroundColor")}
                                                 </Label>
-                                                <Input type="color" value={bgColor}
+                                                <Input type="text" data-coloris value={bgColor}
                                                        onChange={(e) => setBgColor(e.target.value)}
-                                                       className="h-10 w-full cursor-pointer"
+                                                       className="h-10 w-full"
                                                        disabled={bgTransparent}/>
                                             </div>
                                         ) : (
@@ -1047,17 +1047,17 @@ export default function QRDesigner({embedded = false, initialSnapshot = null, on
                                                     <Palette className="size-4"/> {t("designerEditor.styleTab.backgroundGradientToggle")}
                                                 </Label>
                                                 <div className="grid grid-cols-2 gap-2">
-                                                    <Input type="color" value={bgGradStart}
+                                                    <Input type="text" data-coloris value={bgGradStart}
                                                            onChange={(e) => setBgGradStart(e.target.value)}
                                                            disabled={bgTransparent}
                                                            placeholder={t("designerEditor.styleTab.start")}/>
                                                     {bgGradStops === 3 && (
-                                                        <Input type="color" value={bgGradMid}
+                                                        <Input type="text" data-coloris value={bgGradMid}
                                                                onChange={(e) => setBgGradMid(e.target.value)}
                                                                disabled={bgTransparent}
                                                                placeholder={t("designerEditor.styleTab.middle")}/>
                                                     )}
-                                                    <Input type="color" value={bgGradEnd}
+                                                    <Input type="text" data-coloris value={bgGradEnd}
                                                            onChange={(e) => setBgGradEnd(e.target.value)}
                                                            disabled={bgTransparent}
                                                            placeholder={t("designerEditor.styleTab.end")}/>
@@ -1146,9 +1146,9 @@ export default function QRDesigner({embedded = false, initialSnapshot = null, on
                                         <Label className="block mb-2 flex items-center gap-2">
                                             <Palette className="size-4"/> Color
                                         </Label>
-                                        <Input type="color" value={cornerSquareColor}
+                                        <Input type="text" data-coloris value={cornerSquareColor}
                                                onChange={(e) => setCornerSquareColor(e.target.value)}
-                                               className="h-10 w-full cursor-pointer"/>
+                                               className="h-10 w-full"/>
                                     </div>
                                 </div>
 
@@ -1174,9 +1174,9 @@ export default function QRDesigner({embedded = false, initialSnapshot = null, on
                                         <Label className="block mb-2 flex items-center gap-2">
                                             <Palette className="size-4"/> Color
                                         </Label>
-                                        <Input type="color" value={cornerDotColor}
+                                        <Input type="text" data-coloris value={cornerDotColor}
                                                onChange={(e) => setCornerDotColor(e.target.value)}
-                                               className="h-10 w-full cursor-pointer"/>
+                                               className="h-10 w-full"/>
                                     </div>
                                 </div>
                             </div>

--- a/components/qr/BorderTab.jsx
+++ b/components/qr/BorderTab.jsx
@@ -76,10 +76,11 @@ export default function BorderTab({
                 {t("designerEditor.borderTab.ringBackground")}
               </Label>
               <Input
-                type="color"
+                type="text"
+                data-coloris
                 value={ringBackgroundColor}
                 onChange={(e) => setRingBackgroundColor(e.target.value)}
-                className="h-10 w-32 cursor-pointer"
+                className="h-10 w-32"
               />
             </div>
 
@@ -127,10 +128,11 @@ export default function BorderTab({
                   {t("designerEditor.borderTab.innerBorderColor")}
                 </Label>
                 <Input
-                  type="color"
+                  type="text"
+                  data-coloris
                   value={innerBorderColor}
                   onChange={(e) => setInnerBorderColor(e.target.value)}
-                  className="h-10 w-full cursor-pointer"
+                  className="h-10 w-full"
                 />
               </div>
             </div>
@@ -151,10 +153,11 @@ export default function BorderTab({
                   {t("designerEditor.borderTab.outerBorderColor")}
                 </Label>
                 <Input
-                  type="color"
+                  type="text"
+                  data-coloris
                   value={outerBorderColor}
                   onChange={(e) => setOuterBorderColor(e.target.value)}
-                  className="h-10 w-full cursor-pointer"
+                  className="h-10 w-full"
                 />
               </div>
             </div>
@@ -165,11 +168,12 @@ export default function BorderTab({
                 <Palette className="size-4" />
                 {t("designerEditor.borderTab.patternColor")}
               </Label>
-              <Input 
-                type="color" 
-                value={patternColor} 
-                onChange={(e) => setPatternColor(e.target.value)} 
-                className="h-10 w-32 cursor-pointer" 
+              <Input
+                type="text"
+                data-coloris
+                value={patternColor}
+                onChange={(e) => setPatternColor(e.target.value)}
+                className="h-10 w-32"
               />
               <p className="text-xs text-muted-foreground mt-1">
                 {t("designerEditor.borderTab.patternColorDesc")}
@@ -201,11 +205,12 @@ export default function BorderTab({
                   <Label className="block mb-1 text-sm">
                     {t("designerEditor.borderTab.textColor")}
                   </Label>
-                  <Input 
-                    type="color" 
-                    value={borderTextColor} 
-                    onChange={(e) => setBorderTextColor(e.target.value)} 
-                    className="h-10 w-full cursor-pointer" 
+                  <Input
+                    type="text"
+                    data-coloris
+                    value={borderTextColor}
+                    onChange={(e) => setBorderTextColor(e.target.value)}
+                    className="h-10 w-full"
                   />
                 </div>
               </div>

--- a/components/qr/CornersTab.jsx
+++ b/components/qr/CornersTab.jsx
@@ -32,7 +32,7 @@ export default function CornersTab({
       </div>
       <div>
         <label className="block text-sm font-medium mb-1 flex items-center gap-2"><SquareIcon className="size-4"/> {t("designerEditor.cornersTab.cornerSquareColorLabel")}</label>
-        <Input type="color" value={cornerSquareColor} onChange={(e) => setCornerSquareColor(e.target.value)} className="h-10 w-full cursor-pointer" />
+        <Input type="text" data-coloris value={cornerSquareColor} onChange={(e) => setCornerSquareColor(e.target.value)} className="h-10 w-full" />
       </div>
       <div>
         <Label className="block mb-1 flex items-center gap-2"><Circle className="size-4"/> {t("designerEditor.cornersTab.cornerDotLabel")}</Label>
@@ -49,7 +49,7 @@ export default function CornersTab({
       </div>
       <div>
         <label className="block text-sm font-medium mb-1 flex items-center gap-2"><Circle className="size-4"/> {t("designerEditor.cornersTab.cornerDotColorLabel")}</label>
-        <Input type="color" value={cornerDotColor} onChange={(e) => setCornerDotColor(e.target.value)} className="h-10 w-full cursor-pointer" />
+        <Input type="text" data-coloris value={cornerDotColor} onChange={(e) => setCornerDotColor(e.target.value)} className="h-10 w-full" />
       </div>
     </div>
   );

--- a/components/qr/StyleTab.jsx
+++ b/components/qr/StyleTab.jsx
@@ -79,20 +79,20 @@ export default function StyleTab(props) {
         {!dotGradEnabled && (
           <div className="min-w-0">
             <label className="block text-sm font-medium mb-1 flex flex-wrap items-center gap-2"><Palette className="size-4"/> {t("designerEditor.styleTab.dotsColor")}</label>
-            <Input type="color" value={dotColor} onChange={(e) => setDotColor(e.target.value)} className="h-10 w-full cursor-pointer" />
+            <Input type="text" data-coloris value={dotColor} onChange={(e) => setDotColor(e.target.value)} className="h-10 w-full" />
           </div>
         )}
         {dotGradEnabled && (
           <div className="space-y-2 min-w-0">
             <label className="block text-sm font-medium flex flex-wrap items-center gap-2"><Palette className="size-4"/> {t("designerEditor.styleTab.dotsGradient")}</label>
             <div className="grid grid-cols-2 gap-2">
-              <Input type="color" value={dotGradStart} onChange={(e) => setDotGradStart(e.target.value)} />
+              <Input type="text" data-coloris value={dotGradStart} onChange={(e) => setDotGradStart(e.target.value)} />
               {dotGradStops === 3 ? (
-                <Input type="color" value={dotGradMid} onChange={(e) => setDotGradMid(e.target.value)} />
+                <Input type="text" data-coloris value={dotGradMid} onChange={(e) => setDotGradMid(e.target.value)} />
               ) : (
                 <div />
               )}
-              <Input type="color" value={dotGradEnd} onChange={(e) => setDotGradEnd(e.target.value)} />
+              <Input type="text" data-coloris value={dotGradEnd} onChange={(e) => setDotGradEnd(e.target.value)} />
             </div>
             <div className="grid grid-cols-2 gap-2">
               <Select value={dotGradType} onValueChange={setDotGradType}>
@@ -123,18 +123,18 @@ export default function StyleTab(props) {
         <div className="min-w-0">
           <label className="block text-sm font-medium mb-1 flex flex-wrap items-center gap-2"><Palette className="size-4"/> {t("designerEditor.styleTab.background")}</label>
           {!bgGradEnabled && (
-            <Input type="color" value={bgColor} onChange={(e) => setBgColor(e.target.value)} className="h-10 w-full cursor-pointer" disabled={bgTransparent} />
+            <Input type="text" data-coloris value={bgColor} onChange={(e) => setBgColor(e.target.value)} className="h-10 w-full" disabled={bgTransparent} />
           )}
           {bgGradEnabled && (
             <div className="space-y-2">
               <div className="grid grid-cols-2 gap-2">
-                <Input type="color" value={bgGradStart} onChange={(e) => setBgGradStart(e.target.value)} disabled={bgTransparent} />
+                <Input type="text" data-coloris value={bgGradStart} onChange={(e) => setBgGradStart(e.target.value)} disabled={bgTransparent} />
                 {bgGradStops === 3 ? (
-                  <Input type="color" value={bgGradMid} onChange={(e) => setBgGradMid(e.target.value)} disabled={bgTransparent} />
+                  <Input type="text" data-coloris value={bgGradMid} onChange={(e) => setBgGradMid(e.target.value)} disabled={bgTransparent} />
                 ) : (
                   <div />
                 )}
-                <Input type="color" value={bgGradEnd} onChange={(e) => setBgGradEnd(e.target.value)} disabled={bgTransparent} />
+                <Input type="text" data-coloris value={bgGradEnd} onChange={(e) => setBgGradEnd(e.target.value)} disabled={bgTransparent} />
               </div>
               <div className="grid grid-cols-2 gap-2">
                 <Select value={bgGradType} onValueChange={setBgGradType} disabled={bgTransparent}>

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@radix-ui/react-tooltip": "^1.2.8",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "coloris": "^0.19.0",
         "i18next": "^25.4.2",
         "ioredis": "^5.4.1",
         "jspdf": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@radix-ui/react-tooltip": "^1.2.8",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "coloris": "^0.19.0",
     "i18next": "^25.4.2",
     "ioredis": "^5.4.1",
     "jspdf": "^3.0.2",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,4 +1,6 @@
 import "@/styles/globals.css";
+import "coloris/dist/coloris.min.css";
+import Coloris from "coloris";
 import { SessionProvider } from "next-auth/react";
 import { ThemeProvider } from "next-themes";
 import { Toaster } from "@/components/ui/sonner";
@@ -24,6 +26,11 @@ function App({ Component, pageProps: { session, ...pageProps } }) {
       router.replace(router.pathname, router.asPath, { locale: stored });
     }
   }, [router]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    Coloris.init();
+  }, []);
   return (
     <SessionProvider session={session}>
       <ThemeProvider attribute="class" defaultTheme="system" enableSystem>

--- a/script.js
+++ b/script.js
@@ -214,6 +214,10 @@
     // If lib missing, warn early
     ensureLib();
 
+    if (window.Coloris) {
+      window.Coloris.init();
+    }
+
     // Live update on typing and option changes
     els.txt.addEventListener('input', generate);
     els.size.addEventListener('input', generate);

--- a/styles.css
+++ b/styles.css
@@ -63,7 +63,6 @@ body {
 .field label { display: block; margin-bottom: 6px; color: var(--muted); font-size: 0.95rem; }
 .field input[type="text"],
 .field input[type="number"],
-.field input[type="color"],
 .field select {
   width: 100%;
   padding: 10px 12px;
@@ -73,7 +72,7 @@ body {
   color: var(--text);
   outline: none;
 }
-.field input[type="color"] { padding: 2px; height: 40px; }
+.field input[data-coloris] { height: 40px; }
 .hint { display: block; margin-top: 6px; color: var(--muted); font-size: 0.85rem; }
 
 .actions { display: flex; gap: 10px; flex-wrap: wrap; margin-top: 8px; }


### PR DESCRIPTION
## Summary
- replace native color inputs with Coloris-powered fields
- globally load and initialize Coloris
- update vanilla generator to trigger Coloris on load

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: many react/no-unescaped-entities errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bb419bbd0c8324951a132b5175a409