### PR TITLE
Fix QR preview height and center QR canvas

### DIFF
--- a/components/QRDesigner.jsx
+++ b/components/QRDesigner.jsx
@@ -57,6 +57,10 @@ const DOT_TYPES = [
 const CORNER_SQUARE_TYPES = ["square", "extra-rounded", "circle"];
 const CORNER_DOT_TYPES = ["square", "dot"]; // library accepts these
 
+// Maximum QR code preview size in pixels. Keep in sync with the non-React version
+// (script.js) where the QR size is clamped to this value.
+const MAX_PREVIEW = 1024;
+
 export default function QRDesigner({embedded = false, initialSnapshot = null, onSnapshotChange = null}) {
     const ref = useRef(null);
     const qrRef = useRef(null);
@@ -1263,9 +1267,13 @@ export default function QRDesigner({embedded = false, initialSnapshot = null, on
             <Card className="flex items-center justify-center">
                 <CardContent
                     className="flex items-center justify-center p-4"
-                    style={{width: displaySize + 24, height: displaySize + 24}}
+                    style={{width: displaySize + 24, height: MAX_PREVIEW + 24}}
                 >
-                    <div ref={ref} className="flex items-center justify-center"/>
+                    <div
+                        ref={ref}
+                        className="flex items-center justify-center"
+                        style={{width: displaySize, height: displaySize}}
+                    />
                 </CardContent>
             </Card>
             {!embedded && (

--- a/styles.css
+++ b/styles.css
@@ -89,7 +89,7 @@ button:disabled { opacity: 0.6; cursor: not-allowed; }
   position: relative;
   display: grid;
   place-items: center;
-  min-height: 320px;
+  height: 1024px;
   padding: 16px;
   border: 1px dashed var(--border);
   border-radius: 12px;


### PR DESCRIPTION
## Summary
- lock preview height to 1024px and center the QR canvas inside it
- keep non-React preview container height consistent with 1024px limit

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: react/no-unescaped-entities)


------
https://chatgpt.com/codex/tasks/task_e_68bb434f67888324ab75290a323d28d7