### PR TITLE
fix: dynamically import Coloris to avoid SSR window error

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,6 +1,5 @@
 import "@/styles/globals.css";
 import "@melloware/coloris/dist/coloris.css";
-import Coloris from "@melloware/coloris";
 import { SessionProvider } from "next-auth/react";
 import { ThemeProvider } from "next-themes";
 import { Toaster } from "@/components/ui/sonner";
@@ -29,7 +28,9 @@ function App({ Component, pageProps: { session, ...pageProps } }) {
 
   useEffect(() => {
     if (typeof window === "undefined") return;
-    Coloris.init();
+    import("coloris").then(({ default: Coloris }) => {
+      Coloris.init();
+    });
   }, []);
   return (
     <SessionProvider session={session}>


### PR DESCRIPTION
## Summary
- dynamically import Coloris in `_app` to prevent server-side `window` reference

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: react/no-unescaped-entities errors)
- `npm run build` (fails: missing packages `@melloware/coloris/dist/coloris.css` and `coloris`)


------
https://chatgpt.com/codex/tasks/task_e_68bb46c5fb0c832499b96162aa1b9c57