### PR TITLE
refactor: overlay circular border

### DIFF
--- a/docs/CircularBorder.md
+++ b/docs/CircularBorder.md
@@ -18,8 +18,10 @@ Increasing `size` enlarges the overall diameter. A larger `ringWidth` produces a
 
 ## Usage
 
+First render the base QR using `qr-code-styling`, then overlay the ring:
+
 ```js
-await renderCustomQR(canvas, {
+await renderOverlay(canvas, {
   width: 256,
   height: 256,
   borderOptions: {

--- a/docs/QRDesignerModules.md
+++ b/docs/QRDesignerModules.md
@@ -43,7 +43,7 @@ Purpose: Orchestrates the designer UI, manages state for all design options and 
 - `savedPresets`, `presetName`, `cloudPresets`, `cloudSelectedId` – local and cloud preset state.
 
 ### Functions
-- `getPngBlob()` – renders the current canvas to a PNG `Blob` using `renderCustomQR`.
+- `getPngBlob()` – renders the current canvas to a PNG `Blob`.
 - `download(format)` – saves the QR in PNG or SVG format.
 - `downloadPDF()` – exports the QR code to a PDF document.
 - `autoSaveDesign()` – persists the current design snapshot to the server.
@@ -130,7 +130,8 @@ Purpose: Canvas renderer used by the designer to draw QR codes with custom style
 - `outerRadius`, `innerRadius` – radii for the circular border.
 - `textRadius` – radius for border text positioned within the ring.
 ### Functions
-- `renderCustomQR(canvas, options)` – main entry that draws the QR code, optional border, and logo.
+- `renderOverlay(canvas, options)` – draws circular borders or eyes over a QR rendered by `qr-code-styling`.
+- `renderCustomQR(canvas, options)` *(deprecated)* – legacy renderer that drew the entire QR including borders and logos.
 - `drawCircularPattern(ctx, cx, cy, outerR, innerR, opts)` – fills the border ring with a repeating pattern.
 - `drawCircularText(ctx, cx, cy, radius, opts)` – renders text along the circular border.
 - `drawBorderLogo(ctx, cx, cy, radius, opts)` – places a logo somewhere on the border ring.

--- a/lib/customRenderer.js
+++ b/lib/customRenderer.js
@@ -1,5 +1,6 @@
 import QRCode from 'qrcode';
 
+// Deprecated: prefer qr-code-styling for base QR and use renderOverlay for borders
 export async function renderCustomQR(canvas, options) {
     const {
         width = 5000,
@@ -207,6 +208,7 @@ export async function renderOverlay(canvas, options) {
         width = 5000,
         height = 5000,
         backgroundOptions = {},
+        dotsOptions = {},
         cornersSquareOptions = {},
         cornersDotOptions = {},
         borderOptions = {},
@@ -262,7 +264,7 @@ export async function renderOverlay(canvas, options) {
         drawCircularPattern(ctx, centerX, centerY, innerRadius, qrSize / 2, {
             patternColor: borderOptions.patternColor || '#f0f0f0',
             moduleSize,
-            type: 'square',
+            type: dotsOptions.type || 'square',
         });
 
         // Fill ring background between inner and outer
@@ -337,10 +339,7 @@ export async function renderOverlay(canvas, options) {
 }
 
 function drawCircularPattern(ctx, centerX, centerY, innerRadius, qrRadius, options) {
-
     const { patternColor, moduleSize, type } = options;
-
-    ctx.fillStyle = patternColor;
 
     // Iterate over a square grid covering the inner radius
     const step = moduleSize;
@@ -348,7 +347,6 @@ function drawCircularPattern(ctx, centerX, centerY, innerRadius, qrRadius, optio
     const startY = centerY - innerRadius;
     const endX = centerX + innerRadius;
     const endY = centerY + innerRadius;
-
 
     for (let y = startY; y < endY; y += step) {
         for (let x = startX; x < endX; x += step) {
@@ -362,32 +360,14 @@ function drawCircularPattern(ctx, centerX, centerY, innerRadius, qrRadius, optio
 
             // Only draw within the pattern ring, outside the QR square, and with some randomness
             if (dist < innerRadius && !inSquare && Math.random() > 0.6) {
-                const t = String(type);
-                if (t === 'square') {
-                    ctx.fillRect(cx - step / 2, cy - step / 2, step, step);
-                } else if (t === 'dots') {
-                    const inset = step * 0.2;
-                    const r = (step - 2 * inset) / 2;
-                    ctx.beginPath();
-                    ctx.arc(cx, cy, r, 0, 2 * Math.PI);
-                    ctx.fill();
-                } else if (t === 'rounded') {
-                    const inset = step * 0.15;
-                    const inner = step - inset * 2;
-                    const radius = inner * 0.35;
-                    drawRoundedRect(ctx, cx - inner / 2, cy - inner / 2, inner, inner, radius);
-                } else if (t === 'classy') {
-                    const inset = step * 0.15;
-                    const inner = step - inset * 2;
-                    drawRectWithRadii(ctx, cx - inner / 2, cy - inner / 2, inner, inner, {
-                        tl: inner * 0.45,
-                        tr: inner * 0.10,
-                        br: inner * 0.45,
-                        bl: inner * 0.10,
-                    });
-                } else {
-                    ctx.fillRect(cx - step / 2, cy - step / 2, step, step);
-                }
+                drawModule(
+                    ctx,
+                    cx - step / 2,
+                    cy - step / 2,
+                    step,
+                    patternColor,
+                    type,
+                );
             }
         }
     }
@@ -481,8 +461,8 @@ function drawModule(ctx, x, y, size, color, type, neighbors = { top: false, righ
     }
 
     if (t === 'dots') {
-        // radius tuned to better match qr-code-styling
-        const r = size * 0.38;
+        // qr-code-styling dots.ts uses r = size * 0.4
+        const r = size * 0.4;
         ctx.beginPath();
         ctx.arc(x + size / 2, y + size / 2, r, 0, 2 * Math.PI);
         ctx.fill();
@@ -490,7 +470,8 @@ function drawModule(ctx, x, y, size, color, type, neighbors = { top: false, righ
     }
 
     if (t === 'rounded') {
-        const inset = size * 0.05; // smaller inset to match library look
+        // inset and radius per qr-code-styling rounded.ts (inset = size * 0.06)
+        const inset = size * 0.06;
         const inner = size - inset * 2;
         // Per-corner radius depending on neighbors; round only at external corners
         const base = inner * 0.5; // quarter-circle corners when isolated
@@ -503,11 +484,12 @@ function drawModule(ctx, x, y, size, color, type, neighbors = { top: false, righ
     }
 
     if (t === 'classy') {
-        const inset = size * 0.05;
+        // inset = size * 0.06, radii from qr-code-styling classy.ts
+        const inset = size * 0.06;
         const inner = size - inset * 2;
         // Asymmetric radii; zero-out when adjacent to neighbors
         const large = inner * 0.5;
-        const small = inner * 0.25;
+        const small = inner * 0.2;
         const tl = (!neighbors.top && !neighbors.left) ? large : 0;
         const tr = (!neighbors.top && !neighbors.right) ? small : 0;
         const br = (!neighbors.bottom && !neighbors.right) ? large : 0;


### PR DESCRIPTION
## Summary
- Render circular border as overlay on top of qr-code-styling output
- Pass dot and corner styles through overlay so ring pattern matches QR modules
- Document new overlay approach and mark full custom renderer as deprecated

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbc2f4134c832493f005f8c8cd1c0a