### PR TITLE
fix: stabilize QR designer overlay handling

### DIFF
--- a/components/QRDesigner.jsx
+++ b/components/QRDesigner.jsx
@@ -422,23 +422,32 @@ export default function QRDesigner({embedded = false, initialSnapshot = null, on
             qrRef.current.inst.update(libOptions);
         }
 
-        ensureCanvasSize();
-
-        if (circularBorder) {
-            if (!qrRef.current.overlay) {
-                const overlay = document.createElement('canvas');
+        const ensureOverlay = () => {
+            if (!qrRef.current.overlay || !ref.current.contains(qrRef.current.overlay)) {
+                const overlay = qrRef.current.overlay ?? document.createElement('canvas');
                 overlay.style.position = 'absolute';
-                overlay.style.top = '0';
-                overlay.style.left = '0';
+                overlay.style.top = overlay.style.left = '0';
                 ref.current.appendChild(overlay);
                 qrRef.current.overlay = overlay;
             }
+        };
+
+        if (circularBorder) {
+            ensureOverlay();
+        }
+
+        ensureCanvasSize();
+
+        if (circularBorder) {
             setTimeout(() => {
+                ensureOverlay();
                 renderOverlay(qrRef.current.overlay, options);
                 ensureCanvasSize();
             }, 0);
-        } else if (qrRef.current.overlay) {
-            ref.current.removeChild(qrRef.current.overlay);
+        } else {
+            if (qrRef.current.overlay && ref.current.contains(qrRef.current.overlay)) {
+                ref.current.removeChild(qrRef.current.overlay);
+            }
             qrRef.current.overlay = null;
         }
     }, [options, displaySize, circularBorder, cornerSquareType]);


### PR DESCRIPTION
## Summary
- ensure circular border overlay is appended/retained when needed
- guard overlay removal to avoid DOM errors

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities)*
- `npm run build` *(fails: Failed to fetch font `Geist`)*

------
https://chatgpt.com/codex/tasks/task_e_68bbcb4763508324b12b91f77895ca1f