### PR TITLE
Ensure circular border overlay fits in canvas

### DIFF
--- a/components/QRDesigner.jsx
+++ b/components/QRDesigner.jsx
@@ -395,13 +395,42 @@ export default function QRDesigner({embedded = false, initialSnapshot = null, on
 
         const ensureCanvasSize = () => {
             const canvases = ref.current?.querySelectorAll?.('canvas');
-            canvases?.forEach((c) => {
-                c.style.width = `${displaySize}px`;
-                c.style.height = `${displaySize}px`;
-                c.style.position = 'absolute';
-                c.style.top = '0';
-                c.style.left = '0';
-            });
+            const dpr = window.devicePixelRatio || 1;
+
+            if (circularBorder && qrRef.current?.overlay) {
+                const overlayPx = qrRef.current.overlay.width / dpr;
+                const cssSize = overlayPx * (displaySize / size);
+                const offset = (cssSize - displaySize) / 2;
+
+                ref.current.style.width = `${cssSize}px`;
+                ref.current.style.height = `${cssSize}px`;
+
+                canvases?.forEach((c) => {
+                    c.style.position = 'absolute';
+                    if (c === qrRef.current.overlay) {
+                        c.style.width = `${cssSize}px`;
+                        c.style.height = `${cssSize}px`;
+                        c.style.top = '0';
+                        c.style.left = '0';
+                    } else {
+                        c.style.width = `${displaySize}px`;
+                        c.style.height = `${displaySize}px`;
+                        c.style.top = `${offset}px`;
+                        c.style.left = `${offset}px`;
+                    }
+                });
+            } else {
+                ref.current.style.width = `${displaySize}px`;
+                ref.current.style.height = `${displaySize}px`;
+
+                canvases?.forEach((c) => {
+                    c.style.width = `${displaySize}px`;
+                    c.style.height = `${displaySize}px`;
+                    c.style.position = 'absolute';
+                    c.style.top = '0';
+                    c.style.left = '0';
+                });
+            }
         };
 
         const libOptions = {

--- a/lib/customRenderer.js
+++ b/lib/customRenderer.js
@@ -219,14 +219,8 @@ export async function renderOverlay(canvas, options) {
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
 
-    // DPR scaling and transparent backdrop
+    // Device pixel ratio for crisp rendering
     const dpr = window.devicePixelRatio || 1;
-    canvas.width = width * dpr;
-    canvas.height = height * dpr;
-    canvas.style.width = `${width}px`;
-    canvas.style.height = `${height}px`;
-    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
-    ctx.clearRect(0, 0, width, height);
 
     // Recreate QR matrix to align overlay precisely
     const qr = QRCode.create(data, {
@@ -238,28 +232,54 @@ export async function renderOverlay(canvas, options) {
     const quietZone = qrOptions.margin ?? 4;
 
     const totalSize = moduleCount + quietZone * 2;
-    const moduleSize = Math.min(width, height) / totalSize;
+    const baseSize = Math.min(width, height);
+    const moduleSize = baseSize / totalSize;
     const qrSize = moduleCount * moduleSize;
-    const startX = (width - qrSize) / 2;
-    const startY = (height - qrSize) / 2;
-    const centerX = width / 2;
-    const centerY = height / 2;
+    const quietZonePx = quietZone * moduleSize;
+
+    const outerBorderWidth = borderOptions.outerBorderWidth ?? moduleSize;
+    const innerBorderWidth = borderOptions.innerBorderWidth ?? moduleSize;
+    let innerRadius = borderOptions.innerRadius || (
+        qrSize / 2 + quietZonePx + innerBorderWidth / 2
+    );
+    let outerRadius = borderOptions.outerRadius || (
+        innerRadius + quietZonePx + innerBorderWidth / 2 + outerBorderWidth / 2
+    );
+
+    if (outerRadius <= innerRadius) {
+        outerRadius = innerRadius + outerBorderWidth + 1;
+    }
+
+    const requiredHalf = outerRadius + outerBorderWidth / 2;
+    const requiredSize = Math.max(width, height, requiredHalf * 2);
+
+    canvas.width = requiredSize * dpr;
+    canvas.height = requiredSize * dpr;
+    canvas.style.width = `${requiredSize}px`;
+    canvas.style.height = `${requiredSize}px`;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, requiredSize, requiredSize);
+
+    const centerX = requiredSize / 2;
+    const centerY = requiredSize / 2;
+    const startX = (requiredSize - qrSize) / 2;
+    const startY = (requiredSize - qrSize) / 2;
 
     // Prepare background fill (used to mask base finders if needed)
     let backgroundFill = null;
     if (backgroundOptions.gradient) {
-        backgroundFill = createGradient(ctx, width, height, backgroundOptions.gradient);
+        backgroundFill = createGradient(
+            ctx,
+            requiredSize,
+            requiredSize,
+            backgroundOptions.gradient
+        );
     } else if (backgroundOptions.color && backgroundOptions.color !== 'transparent') {
         backgroundFill = backgroundOptions.color;
     }
 
     // Circular border overlay (ring, pattern, text, logo)
     if (borderOptions?.circularBorder) {
-        const outerBorderWidth = borderOptions.outerBorderWidth ?? moduleSize;
-        const innerBorderWidth = borderOptions.innerBorderWidth ?? moduleSize;
-        const outerRadius = borderOptions.outerRadius || (Math.min(width, height) / 2 - outerBorderWidth / 2);
-        const innerRadius = borderOptions.innerRadius || (qrSize / 2 + moduleSize * 4);
-
         // Pattern ring inside inner radius
         drawCircularPattern(ctx, centerX, centerY, innerRadius, qrSize / 2, {
             patternColor: borderOptions.patternColor || '#f0f0f0',


### PR DESCRIPTION
## Summary
- Account for quiet zone and border widths when calculating overlay radii
- Expand overlay canvas and re-center drawing if border extends past current bounds
- Resize preview container and overlay canvas so circular borders render without clipping

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities)*
- `npm run build` *(fails: Failed to fetch font `Geist` / `Geist Mono`)*

------
https://chatgpt.com/codex/tasks/task_e_68bcf37519b88324a6189902cf7e0592