### PR TITLE
feat: replace color inputs with reusable color picker

### DIFF
--- a/components/QRDesigner.jsx
+++ b/components/QRDesigner.jsx
@@ -3,6 +3,7 @@
 import {useEffect, useMemo, useRef, useState} from "react";
 import QRCode from 'qrcode';
 import {Input} from "@/components/ui/input";
+import ColorPicker from "@/components/ui/color-picker";
 import {Label} from "@/components/ui/label";
 import {
     Select,
@@ -1111,9 +1112,9 @@ export default function QRDesigner({embedded = false, initialSnapshot = null, on
                                                         <Palette
                                                             className="size-4"/> {t("designerEditor.styleTab.dotsColor")}
                                                     </Label>
-                                                    <Input type="color" value={dotColor}
-                                                           onChange={(e) => setDotColor(e.target.value)}
-                                                           className="h-10 w-full cursor-pointer"/>
+                                                    <ColorPicker color={dotColor}
+                                                                 onChange={setDotColor}
+                                                                 className="h-10 w-full cursor-pointer"/>
                                                 </div>
                                             ) : (
                                                 <div className="space-y-3">
@@ -1122,17 +1123,17 @@ export default function QRDesigner({embedded = false, initialSnapshot = null, on
                                                             className="size-4"/> {t("designerEditor.styleTab.dotsGradient")}
                                                     </Label>
                                                     <div className="grid grid-cols-2 gap-2">
-                                                        <Input type="color" value={dotGradStart}
-                                                               onChange={(e) => setDotGradStart(e.target.value)}
-                                                               placeholder={t("designerEditor.styleTab.start")}/>
+                                                        <ColorPicker color={dotGradStart}
+                                                                     onChange={setDotGradStart}
+                                                                     placeholder={t("designerEditor.styleTab.start")}/>
                                                         {dotGradStops === 3 && (
-                                                            <Input type="color" value={dotGradMid}
-                                                                   onChange={(e) => setDotGradMid(e.target.value)}
-                                                                   placeholder={t("designerEditor.styleTab.middle")}/>
+                                                            <ColorPicker color={dotGradMid}
+                                                                         onChange={setDotGradMid}
+                                                                         placeholder={t("designerEditor.styleTab.middle")}/>
                                                         )}
-                                                        <Input type="color" value={dotGradEnd}
-                                                               onChange={(e) => setDotGradEnd(e.target.value)}
-                                                               placeholder={t("designerEditor.styleTab.end")}/>
+                                                        <ColorPicker color={dotGradEnd}
+                                                                     onChange={setDotGradEnd}
+                                                                     placeholder={t("designerEditor.styleTab.end")}/>
                                                     </div>
                                                     <div className="grid grid-cols-2 gap-2">
                                                         <Select value={dotGradType} onValueChange={setDotGradType}>
@@ -1180,10 +1181,10 @@ export default function QRDesigner({embedded = false, initialSnapshot = null, on
                                                         <Palette
                                                             className="size-4"/> {t("designerEditor.styleTab.backgroundColor")}
                                                     </Label>
-                                                    <Input type="color" value={bgColor}
-                                                           onChange={(e) => setBgColor(e.target.value)}
-                                                           className="h-10 w-full cursor-pointer"
-                                                           disabled={bgTransparent}/>
+                                                    <ColorPicker color={bgColor}
+                                                                 onChange={setBgColor}
+                                                                 className="h-10 w-full cursor-pointer"
+                                                                 disabled={bgTransparent}/>
                                                 </div>
                                             ) : (
                                                 <div className="space-y-3">
@@ -1192,20 +1193,20 @@ export default function QRDesigner({embedded = false, initialSnapshot = null, on
                                                             className="size-4"/> {t("designerEditor.styleTab.backgroundGradientToggle")}
                                                     </Label>
                                                     <div className="grid grid-cols-2 gap-2">
-                                                        <Input type="color" value={bgGradStart}
-                                                               onChange={(e) => setBgGradStart(e.target.value)}
-                                                               disabled={bgTransparent}
-                                                               placeholder={t("designerEditor.styleTab.start")}/>
+                                                        <ColorPicker color={bgGradStart}
+                                                                     onChange={setBgGradStart}
+                                                                     disabled={bgTransparent}
+                                                                     placeholder={t("designerEditor.styleTab.start")}/>
                                                         {bgGradStops === 3 && (
-                                                            <Input type="color" value={bgGradMid}
-                                                                   onChange={(e) => setBgGradMid(e.target.value)}
-                                                                   disabled={bgTransparent}
-                                                                   placeholder={t("designerEditor.styleTab.middle")}/>
+                                                            <ColorPicker color={bgGradMid}
+                                                                         onChange={setBgGradMid}
+                                                                         disabled={bgTransparent}
+                                                                         placeholder={t("designerEditor.styleTab.middle")}/>
                                                         )}
-                                                        <Input type="color" value={bgGradEnd}
-                                                               onChange={(e) => setBgGradEnd(e.target.value)}
-                                                               disabled={bgTransparent}
-                                                               placeholder={t("designerEditor.styleTab.end")}/>
+                                                        <ColorPicker color={bgGradEnd}
+                                                                     onChange={setBgGradEnd}
+                                                                     disabled={bgTransparent}
+                                                                     placeholder={t("designerEditor.styleTab.end")}/>
                                                     </div>
                                                     <div className="grid grid-cols-2 gap-2">
                                                         <Select value={bgGradType} onValueChange={setBgGradType}
@@ -1296,9 +1297,9 @@ export default function QRDesigner({embedded = false, initialSnapshot = null, on
                                         <Label className="block mb-2 flex items-center gap-2">
                                             <Palette className="size-4"/> Color
                                         </Label>
-                                        <Input type="color" value={cornerSquareColor}
-                                               onChange={(e) => setCornerSquareColor(e.target.value)}
-                                               className="h-10 w-full cursor-pointer"/>
+                                        <ColorPicker color={cornerSquareColor}
+                                                     onChange={setCornerSquareColor}
+                                                     className="h-10 w-full cursor-pointer"/>
                                     </div>
                                 </div>
 
@@ -1324,9 +1325,9 @@ export default function QRDesigner({embedded = false, initialSnapshot = null, on
                                         <Label className="block mb-2 flex items-center gap-2">
                                             <Palette className="size-4"/> Color
                                         </Label>
-                                        <Input type="color" value={cornerDotColor}
-                                               onChange={(e) => setCornerDotColor(e.target.value)}
-                                               className="h-10 w-full cursor-pointer"/>
+                                        <ColorPicker color={cornerDotColor}
+                                                     onChange={setCornerDotColor}
+                                                     className="h-10 w-full cursor-pointer"/>
                                     </div>
                                 </div>
                             </div>

--- a/components/qr/BorderTab.jsx
+++ b/components/qr/BorderTab.jsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Input } from "@/components/ui/input";
+import ColorPicker from "@/components/ui/color-picker";
 import { Label } from "@/components/ui/label";
 import { Slider } from "@/components/ui/slider";
 import { Switch } from "@/components/ui/switch";
@@ -83,10 +84,9 @@ export default function BorderTab({
               <Label className="block mb-2 flex items-center gap-2">
                 {t("designerEditor.borderTab.ringBackground")}
               </Label>
-              <Input
-                type="color"
-                value={ringBackgroundColor}
-                onChange={(e) => setRingBackgroundColor(e.target.value)}
+              <ColorPicker
+                color={ringBackgroundColor}
+                onChange={setRingBackgroundColor}
                 className="h-10 w-32 cursor-pointer"
               />
             </div>
@@ -134,10 +134,9 @@ export default function BorderTab({
                 <Label className="block mb-1 text-sm">
                   {t("designerEditor.borderTab.innerBorderColor")}
                 </Label>
-                <Input
-                  type="color"
-                  value={innerBorderColor}
-                  onChange={(e) => setInnerBorderColor(e.target.value)}
+                <ColorPicker
+                  color={innerBorderColor}
+                  onChange={setInnerBorderColor}
                   className="h-10 w-full cursor-pointer"
                 />
               </div>
@@ -158,10 +157,9 @@ export default function BorderTab({
                 <Label className="block mb-1 text-sm">
                   {t("designerEditor.borderTab.outerBorderColor")}
                 </Label>
-                <Input
-                  type="color"
-                  value={outerBorderColor}
-                  onChange={(e) => setOuterBorderColor(e.target.value)}
+                <ColorPicker
+                  color={outerBorderColor}
+                  onChange={setOuterBorderColor}
                   className="h-10 w-full cursor-pointer"
                 />
               </div>
@@ -173,11 +171,10 @@ export default function BorderTab({
                 <Palette className="size-4" />
                 {t("designerEditor.borderTab.patternColor")}
               </Label>
-              <Input 
-                type="color" 
-                value={patternColor} 
-                onChange={(e) => setPatternColor(e.target.value)} 
-                className="h-10 w-32 cursor-pointer" 
+              <ColorPicker
+                color={patternColor}
+                onChange={setPatternColor}
+                className="h-10 w-32 cursor-pointer"
               />
               <p className="text-xs text-muted-foreground mt-1">
                 {t("designerEditor.borderTab.patternColorDesc")}
@@ -229,11 +226,10 @@ export default function BorderTab({
                   <Label className="block mb-1 text-sm">
                     {t("designerEditor.borderTab.textColor")}
                   </Label>
-                  <Input 
-                    type="color" 
-                    value={borderTextColor} 
-                    onChange={(e) => setBorderTextColor(e.target.value)} 
-                    className="h-10 w-full cursor-pointer" 
+                  <ColorPicker
+                    color={borderTextColor}
+                    onChange={setBorderTextColor}
+                    className="h-10 w-full cursor-pointer"
                   />
                 </div>
               </div>

--- a/components/qr/CornersTab.jsx
+++ b/components/qr/CornersTab.jsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Input } from "@/components/ui/input";
+import ColorPicker from "@/components/ui/color-picker";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Square as SquareIcon, Circle } from "lucide-react";
@@ -32,7 +33,7 @@ export default function CornersTab({
       </div>
       <div>
         <label className="block text-sm font-medium mb-1 flex items-center gap-2"><SquareIcon className="size-4"/> {t("designerEditor.cornersTab.cornerSquareColorLabel")}</label>
-        <Input type="color" value={cornerSquareColor} onChange={(e) => setCornerSquareColor(e.target.value)} className="h-10 w-full cursor-pointer" />
+        <ColorPicker color={cornerSquareColor} onChange={setCornerSquareColor} className="h-10 w-full cursor-pointer" />
       </div>
       <div>
         <Label className="block mb-1 flex items-center gap-2"><Circle className="size-4"/> {t("designerEditor.cornersTab.cornerDotLabel")}</Label>
@@ -49,7 +50,7 @@ export default function CornersTab({
       </div>
       <div>
         <label className="block text-sm font-medium mb-1 flex items-center gap-2"><Circle className="size-4"/> {t("designerEditor.cornersTab.cornerDotColorLabel")}</label>
-        <Input type="color" value={cornerDotColor} onChange={(e) => setCornerDotColor(e.target.value)} className="h-10 w-full cursor-pointer" />
+        <ColorPicker color={cornerDotColor} onChange={setCornerDotColor} className="h-10 w-full cursor-pointer" />
       </div>
     </div>
   );

--- a/components/qr/StyleTab.jsx
+++ b/components/qr/StyleTab.jsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Input } from "@/components/ui/input";
+import ColorPicker from "@/components/ui/color-picker";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Slider } from "@/components/ui/slider";
@@ -79,20 +80,20 @@ export default function StyleTab(props) {
         {!dotGradEnabled && (
           <div className="min-w-0">
             <label className="block text-sm font-medium mb-1 flex flex-wrap items-center gap-2"><Palette className="size-4"/> {t("designerEditor.styleTab.dotsColor")}</label>
-            <Input type="color" value={dotColor} onChange={(e) => setDotColor(e.target.value)} className="h-10 w-full cursor-pointer" />
+            <ColorPicker color={dotColor} onChange={setDotColor} className="h-10 w-full cursor-pointer" />
           </div>
         )}
         {dotGradEnabled && (
           <div className="space-y-2 min-w-0">
             <label className="block text-sm font-medium flex flex-wrap items-center gap-2"><Palette className="size-4"/> {t("designerEditor.styleTab.dotsGradient")}</label>
             <div className="grid grid-cols-2 gap-2">
-              <Input type="color" value={dotGradStart} onChange={(e) => setDotGradStart(e.target.value)} />
+              <ColorPicker color={dotGradStart} onChange={setDotGradStart} />
               {dotGradStops === 3 ? (
-                <Input type="color" value={dotGradMid} onChange={(e) => setDotGradMid(e.target.value)} />
+                <ColorPicker color={dotGradMid} onChange={setDotGradMid} />
               ) : (
                 <div />
               )}
-              <Input type="color" value={dotGradEnd} onChange={(e) => setDotGradEnd(e.target.value)} />
+              <ColorPicker color={dotGradEnd} onChange={setDotGradEnd} />
             </div>
             <div className="grid grid-cols-2 gap-2">
               <Select value={dotGradType} onValueChange={setDotGradType}>
@@ -123,18 +124,18 @@ export default function StyleTab(props) {
         <div className="min-w-0">
           <label className="block text-sm font-medium mb-1 flex flex-wrap items-center gap-2"><Palette className="size-4"/> {t("designerEditor.styleTab.background")}</label>
           {!bgGradEnabled && (
-            <Input type="color" value={bgColor} onChange={(e) => setBgColor(e.target.value)} className="h-10 w-full cursor-pointer" disabled={bgTransparent} />
+            <ColorPicker color={bgColor} onChange={setBgColor} className="h-10 w-full cursor-pointer" disabled={bgTransparent} />
           )}
           {bgGradEnabled && (
             <div className="space-y-2">
               <div className="grid grid-cols-2 gap-2">
-                <Input type="color" value={bgGradStart} onChange={(e) => setBgGradStart(e.target.value)} disabled={bgTransparent} />
+                <ColorPicker color={bgGradStart} onChange={setBgGradStart} disabled={bgTransparent} />
                 {bgGradStops === 3 ? (
-                  <Input type="color" value={bgGradMid} onChange={(e) => setBgGradMid(e.target.value)} disabled={bgTransparent} />
+                  <ColorPicker color={bgGradMid} onChange={setBgGradMid} disabled={bgTransparent} />
                 ) : (
                   <div />
                 )}
-                <Input type="color" value={bgGradEnd} onChange={(e) => setBgGradEnd(e.target.value)} disabled={bgTransparent} />
+                <ColorPicker color={bgGradEnd} onChange={setBgGradEnd} disabled={bgTransparent} />
               </div>
               <div className="grid grid-cols-2 gap-2">
                 <Select value={bgGradType} onValueChange={setBgGradType} disabled={bgTransparent}>

--- a/components/ui/color-picker.jsx
+++ b/components/ui/color-picker.jsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { SketchPicker } from "react-color";
+import { useEffect, useState } from "react";
+
+export function ColorPicker({ color, onChange, disabled, ...props }) {
+  const [recentColors, setRecentColors] = useState([]);
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      try {
+        const stored = window.localStorage.getItem("recentColors");
+        if (stored) {
+          const parsed = JSON.parse(stored);
+          if (Array.isArray(parsed)) {
+            setRecentColors(parsed);
+          }
+        }
+      } catch {
+        // Ignore parse errors
+      }
+    }
+  }, []);
+
+  const handleChangeComplete = (c) => {
+    if (disabled) return;
+    const hex = c.hex;
+    const updated = [hex, ...recentColors.filter((col) => col !== hex)].slice(0, 8);
+    setRecentColors(updated);
+    try {
+      if (typeof window !== "undefined") {
+        window.localStorage.setItem("recentColors", JSON.stringify(updated));
+      }
+    } catch {
+      // Ignore storage errors
+    }
+    onChange?.(hex);
+  };
+
+  return (
+    <div style={disabled ? { pointerEvents: "none", opacity: 0.5 } : undefined}>
+      <SketchPicker
+        color={color}
+        onChangeComplete={handleChangeComplete}
+        presetColors={recentColors}
+        {...props}
+      />
+    </div>
+  );
+}
+
+export default ColorPicker;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.1.0",
       "dependencies": {
         "@google-cloud/translate": "^8.4.0",
-        "@melloware/coloris": "^0.25.0",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-label": "^2.1.7",
@@ -942,12 +941,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
       }
-    },
-    "node_modules/@melloware/coloris": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@melloware/coloris/-/coloris-0.25.0.tgz",
-      "integrity": "sha512-RBWVFLjWbup7GRkOXb9g3+ZtR9AevFtJinrRz2cYPLjZ3TCkNRGMWuNbmQWbZ5cF3VU7aQDZwUsYgIY/bGrh2g==",
-      "license": "MIT"
     },
     "node_modules/@mongodb-js/saslprep": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   },
   "dependencies": {
     "@google-cloud/translate": "^8.4.0",
-    "@melloware/coloris": "^0.25.0",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.7",
@@ -39,6 +38,7 @@
     "qrcode": "^1.5.3",
     "qrcode-generator": "^1.4.4",
     "react": "19.1.0",
+    "react-color": "^2.19.3",
     "react-dom": "19.1.0",
     "react-i18next": "^15.7.3",
     "sharp": "^0.33.4",

--- a/styles.css
+++ b/styles.css
@@ -63,7 +63,6 @@ body {
 .field label { display: block; margin-bottom: 6px; color: var(--muted); font-size: 0.95rem; }
 .field input[type="text"],
 .field input[type="number"],
-.field input[type="color"],
 .field select {
   width: 100%;
   padding: 10px 12px;
@@ -73,7 +72,6 @@ body {
   color: var(--text);
   outline: none;
 }
-.field input[type="color"] { padding: 2px; height: 40px; }
 .hint { display: block; margin-top: 6px; color: var(--muted); font-size: 0.85rem; }
 
 .actions { display: flex; gap: 10px; flex-wrap: wrap; margin-top: 8px; }


### PR DESCRIPTION
## Summary
- add `react-color`-based picker component with recent color storage
- swap out native `<input type="color">` controls for new picker
- remove leftover native color input styles

## Testing
- `npm install` *(fails: 403 Forbidden for react-color)*
- `npm run lint` *(fails: react/no-unescaped-entities warnings/errors)*
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Can't resolve 'react-color')*

------
https://chatgpt.com/codex/tasks/task_e_68bd3c5cc8f083249a96438298480e02